### PR TITLE
Feat/map

### DIFF
--- a/src/main/java/com/wooyah/controller/CartController.java
+++ b/src/main/java/com/wooyah/controller/CartController.java
@@ -2,17 +2,19 @@ package com.wooyah.controller;
 
 import com.wooyah.dto.cart.CartDTO;
 import com.wooyah.dto.common.ApiResponse;
+import com.wooyah.dto.common.PaginationListDTO;
 import com.wooyah.dto.product.ProductDTO;
 import com.wooyah.service.CartService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.Response;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -22,12 +24,27 @@ public class CartController {
     private final CartService cartService;
     @GetMapping("/{cartId}")
     public ApiResponse<CartDTO.Detail> getCartDetail(@PathVariable Long cartId){
-        CartDTO.Detail response =cartService.getDetail(cartId);
+        CartDTO.Detail response = cartService.getDetail(cartId);
+
         return ApiResponse.<CartDTO.Detail>builder()
                 .isSuccess(true)
                 .code(HttpStatus.OK.value())
                 .message("글 세부 정보")
                 .result(response)
+                .build();
+    }
+
+    @GetMapping("/locations")
+    public ApiResponse<PaginationListDTO<CartDTO.Near>> getNearCarts(@RequestParam(value="zoom", defaultValue="1") int zoom){
+        // TODO 해당 부분 JWT 이용해서 변경
+        Long userId = 1L;
+        PaginationListDTO<CartDTO.Near> nearCarts = cartService.getNearCarts(userId, zoom);
+
+        return ApiResponse.<PaginationListDTO<CartDTO.Near>>builder()
+                .isSuccess(true)
+                .code(HttpStatus.OK.value())
+                .message("지도 카트 목록 표시")
+                .result(nearCarts)
                 .build();
     }
 }

--- a/src/main/java/com/wooyah/dto/cart/CartDTO.java
+++ b/src/main/java/com/wooyah/dto/cart/CartDTO.java
@@ -6,6 +6,7 @@ import com.wooyah.entity.CartProduct;
 import lombok.Builder;
 import lombok.Data;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public class CartDTO {
@@ -28,6 +29,22 @@ public class CartDTO {
                     .nickname(cart.getOwnerNickname())
                     .shoppingLocation(cart.getShoppingLocation())
                     .products(productDetails)
+                    .build();
+        }
+    }
+
+    @Data
+    @Builder
+    public static class Near {
+        private Long cartId;
+        private BigDecimal latitude;
+        private BigDecimal longitude;
+
+        public static Near from(Cart cart) {
+            return Near.builder()
+                    .cartId(cart.getId())
+                    .latitude(cart.getLatitude())
+                    .longitude(cart.getLongitude())
                     .build();
         }
     }

--- a/src/main/java/com/wooyah/dto/common/PaginationListDTO.java
+++ b/src/main/java/com/wooyah/dto/common/PaginationListDTO.java
@@ -1,0 +1,17 @@
+package com.wooyah.dto.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class PaginationListDTO<T> {
+
+    private Number count;
+    private List<T> data;
+
+}

--- a/src/main/java/com/wooyah/exceptions/ExceptionMessage.java
+++ b/src/main/java/com/wooyah/exceptions/ExceptionMessage.java
@@ -1,0 +1,13 @@
+package com.wooyah.exceptions;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ExceptionMessage {
+    USER_NOT_FOUND("해당하는 사용자를 찾을 수 없습니다"),
+    CART_NOT_FOUND("해당하는 카트를 찾을 수 없습니다");
+
+    private final String message;
+}

--- a/src/main/java/com/wooyah/repository/CartRepository.java
+++ b/src/main/java/com/wooyah/repository/CartRepository.java
@@ -2,6 +2,17 @@ package com.wooyah.repository;
 
 import com.wooyah.entity.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
+    @Query(value = "SELECT *, " +
+            "(6371 * acos(cos(radians(?1)) * cos(radians(c.latitude)) " +
+            "* cos(radians(c.longitude) - radians(?2)) + sin(radians(?1)) " +
+            "* sin(radians(c.latitude)))) AS distance " +
+            "FROM carts c ORDER BY distance ASC LIMIT ?3", nativeQuery = true)
+    List<Cart> findCartsNearestTo(BigDecimal latitude, BigDecimal longitude, int limit);
+
 }

--- a/src/main/java/com/wooyah/service/CartService.java
+++ b/src/main/java/com/wooyah/service/CartService.java
@@ -1,21 +1,43 @@
 package com.wooyah.service;
 
 import com.wooyah.dto.cart.CartDTO;
+import com.wooyah.dto.common.PaginationListDTO;
 import com.wooyah.entity.Cart;
+import com.wooyah.entity.User;
+import com.wooyah.exceptions.ExceptionMessage;
 import com.wooyah.repository.CartRepository;
+import com.wooyah.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CartService {
     private final CartRepository cartRepository;
-
+    private final UserRepository userRepository;
     public CartDTO.Detail getDetail(Long cartId){
-        Cart findCart = cartRepository.findById(cartId).orElseThrow(() -> new IllegalArgumentException("cartId에 해당하는 cart가 존재하지 않습니다."));
+        Cart findCart = cartRepository.findById(cartId).orElseThrow(() -> new IllegalArgumentException(ExceptionMessage.CART_NOT_FOUND.getMessage()));
 
         return CartDTO.Detail.from(findCart);
     }
+
+    public PaginationListDTO<CartDTO.Near> getNearCarts(Long userId, int zoom) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+        List<Cart> findCarts = cartRepository.findCartsNearestTo(user.getLongitude(), user.getLatitude(), zoom*5);
+
+        List<CartDTO.Near> nearCarts = findCarts.stream()
+                .map(CartDTO.Near::from)
+                .toList();
+
+        return PaginationListDTO.<CartDTO.Near>builder()
+                .count(nearCarts.size())
+                .data(nearCarts)
+                .build();
+    }
+
+
 }

--- a/src/test/java/com/wooyah/repository/CartRepositoryTest.java
+++ b/src/test/java/com/wooyah/repository/CartRepositoryTest.java
@@ -1,0 +1,78 @@
+package com.wooyah.repository;
+
+import com.wooyah.entity.Cart;
+import com.wooyah.entity.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class CartRepositoryTest{
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private CartRepository cartRepository;
+
+    private User user;
+
+    @BeforeEach
+    public void setUp() {
+        user = User.builder()
+                .nickname("Test User")
+                .longitude(BigDecimal.valueOf(38.000000))
+                .latitude(BigDecimal.valueOf(127.000000))
+                .build();
+
+        entityManager.persist(user);
+    }
+
+    @AfterEach
+    void tearDown(){
+        cartRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("특정 유저 위치에서 가까운 Cart들을 조회할 수 있다.")
+    void findCartsNearestTo() {
+        final int LIMIT = 2;
+        // given
+        List<Cart> carts = List.of(
+                createCart(BigDecimal.valueOf(38.200000), BigDecimal.valueOf(127.200000)),
+                createCart(BigDecimal.valueOf(38.100000), BigDecimal.valueOf(127.100000)),
+                createCart(BigDecimal.valueOf(38.300000), BigDecimal.valueOf(127.300000)),
+                createCart(BigDecimal.valueOf(38.500000), BigDecimal.valueOf(127.500000)),
+                createCart(BigDecimal.valueOf(38.400000), BigDecimal.valueOf(127.400000)));
+        cartRepository.saveAll(carts);
+
+        //when
+        List<Cart> nearestCarts = cartRepository.findCartsNearestTo(user.getLongitude(), user.getLatitude(), LIMIT);
+
+        //then
+        assertThat(nearestCarts).hasSize(2)
+                .extracting("longitude")
+                .containsExactlyInAnyOrder(
+                        BigDecimal.valueOf(38.100000),
+                        BigDecimal.valueOf(38.200000));
+
+    }
+
+    private Cart createCart(BigDecimal longitude, BigDecimal latitude){
+        return Cart.builder()
+                .longitude(longitude)
+                .latitude(latitude)
+                .build();
+    }
+}

--- a/src/test/java/com/wooyah/service/CartServiceTest.java
+++ b/src/test/java/com/wooyah/service/CartServiceTest.java
@@ -2,26 +2,24 @@ package com.wooyah.service;
 
 import com.wooyah.IntegrationTestSupport;
 import com.wooyah.dto.cart.CartDTO;
+import com.wooyah.dto.common.PaginationListDTO;
 import com.wooyah.entity.*;
-import com.wooyah.entity.enums.CartStatus;
 import com.wooyah.repository.CartRepository;
-import com.wooyah.repository.UserRepository;
+
 import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.AfterEach;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Transactional
@@ -33,6 +31,9 @@ class CartServiceTest extends IntegrationTestSupport {
     @Autowired
     private EntityManager entityManager;
 
+    @Autowired
+    private CartRepository cartRepository;
+
     private User user;
     private Product product;
     private Cart cart;
@@ -43,10 +44,23 @@ class CartServiceTest extends IntegrationTestSupport {
     public void setUp() {
         user = User.builder()
                 .nickname("Test User")
+                .longitude(BigDecimal.valueOf(0.000000))
+                .latitude(BigDecimal.valueOf(0.000000))
                 .build();
         product = Product.builder()
                 .productName("Test Product")
                 .build();
+
+        entityManager.persist(user);
+        entityManager.persist(product);
+
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("요청 받은 cartId의 cart 세부 정보를 확인할 수 있다.")
+    void getDetail_withValidId() {
+        //given
         cart = Cart.builder()
                 .shoppingLocation("Test Location")
                 .build();
@@ -60,22 +74,12 @@ class CartServiceTest extends IntegrationTestSupport {
                 .product(product)
                 .build();
 
-        entityManager.persist(user);
-        entityManager.persist(product);
         entityManager.persist(cart);
         entityManager.persist(cartUser);
         entityManager.persist(cartProduct);
 
         cart.addCartUser(cartUser);
         cart.addCartProduct(cartProduct);
-
-    }
-
-    @Test
-    @Transactional
-    @DisplayName("요청 받은 cartId의 cart 세부 정보를 확인할 수 있다.")
-    void getDetail_withValidId() {
-        //given
 
         //when
         CartDTO.Detail result = cartService.getDetail(cart.getId());
@@ -91,9 +95,60 @@ class CartServiceTest extends IntegrationTestSupport {
     @Test
     @Transactional
     @DisplayName("요청 받은 cartId의 cart가 없는 경우 Exception을 throw 한다.")
-    public void getDetail_withInvalidId() {
+    public void getDetail_withInvalidCartId() {
         // when & then
-        assertThrows(IllegalArgumentException.class, () -> cartService.getDetail(9999L)); // 존재하지 않는 id
+        assertThatThrownBy(() -> cartService.getDetail(-1L)) // 존재하지 않는 id
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당하는 카트를 찾을 수 없습니다");
+
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("특정 유저와 가까운 Cart를 지도 zoom*5개 조회할 수 있다.")
+    public void getNearCarts(){
+        Integer zoom = 1;
+        //given
+        List<Cart> carts = List.of(
+                createCart(BigDecimal.valueOf(38.200000), BigDecimal.valueOf(127.200000)),
+                createCart(BigDecimal.valueOf(38.100000), BigDecimal.valueOf(127.100000)),
+                createCart(BigDecimal.valueOf(38.400000), BigDecimal.valueOf(127.400000)),
+                createCart(BigDecimal.valueOf(38.300000), BigDecimal.valueOf(127.300000)),
+                createCart(BigDecimal.valueOf(38.600000), BigDecimal.valueOf(127.600000)),
+                createCart(BigDecimal.valueOf(38.500000), BigDecimal.valueOf(127.500000)),
+                createCart(BigDecimal.valueOf(38.800000), BigDecimal.valueOf(127.800000)),
+                createCart(BigDecimal.valueOf(38.700000), BigDecimal.valueOf(127.700000))
+        );
+        cartRepository.saveAll(carts);
+
+        //when
+        PaginationListDTO<CartDTO.Near> nearCarts = cartService.getNearCarts(user.getId(), zoom);
+
+        assertThat(nearCarts.getCount()).isEqualTo(5);
+        assertThat(nearCarts.getData()).hasSize(5)
+                .extracting("longitude")
+                .containsExactlyInAnyOrder(
+                        BigDecimal.valueOf(38.100000), BigDecimal.valueOf(38.200000),
+                        BigDecimal.valueOf(38.300000), BigDecimal.valueOf(38.400000),
+                        BigDecimal.valueOf(38.500000));
+
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("요청받은 userId의 user가 존재하지 않는 경우  Exception을 throw 한다.")
+    public void getNearCarts_withInvalidUserId(){
+        assertThatThrownBy(() -> cartService.getNearCarts(-1L, 1)) // 존재하지 않는 id
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("해당하는 사용자를 찾을 수 없습니다");
+    }
+
+
+    private Cart createCart(BigDecimal longitude, BigDecimal latitude){
+        return Cart.builder()
+                .longitude(longitude)
+                .latitude(latitude)
+                .build();
     }
 
 }


### PR DESCRIPTION
1. 특정 유저 근처에 있는 카트 조회
 - 현재는 로그인 기능이 완성되지 않아 userId가 1인 유저로 설정 (로그인 기능 완성 후 리팩토링 예정)
 - 네이버 API zoom값 1을 기준으로 5개씩 조회, (zoom*5개 조회)
    -> 통신하고 지도 보면서 적절한 값으로 교체

2. PaginationDTO 추가
- Pageable 사용하는 api는 해당 DTO를 사용해서 반환

3. ExceptionMessage enum class 추가
- 에러 메세지 처리

4. 테스트 코드 추가
- 특정 유저 주변 카트 조회시 native 쿼리로 작성하여 repository test 추가
- service 단위 테스트 추가